### PR TITLE
Add magic repository support into manager

### DIFF
--- a/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
@@ -610,11 +610,18 @@ abstract class BaseManager
      *
      * @param string $method
      * @param array $arguments
-     * @return array|object The found entity/entities
+     * @return mixed The found entity/entities
      * @throws \BadMethodCallException
      */
     public function __call($method, $arguments)
     {
+        // proxy to repository method if exists
+        $reflectedClass = new \ReflectionClass($this->repository);
+        if ($reflectedClass->hasMethod($method)) {
+            return call_user_func_array([$this->repository, $method], $arguments);
+        }
+
+        // proxy to Symfony/Doctrine magic finders
         return $this->repository->__call($method, $arguments);
     }
 }

--- a/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
@@ -618,7 +618,7 @@ abstract class BaseManager
         // proxy to repository method if exists
         $reflectedClass = new \ReflectionClass($this->repository);
         if ($reflectedClass->hasMethod($method)) {
-            return call_user_func_array([$this->repository, $method], $arguments);
+            return call_user_func_array(array($this->repository, $method), $arguments);
         }
 
         // proxy to Symfony/Doctrine magic finders

--- a/src/Skwi/Bundle/ProjectBaseBundle/Tests/Units/Manager/BaseManager.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Tests/Units/Manager/BaseManager.php
@@ -260,6 +260,12 @@ class BaseManager extends Units\Test
                 ->mock($this->mockRepository)
                     ->call('__call')->never()
                     ->call('find')->once()
+
+            ->if($instance = $this->createTestedClass())
+            ->when($instance->findCustom())
+            ->then
+                ->mock($this->mockRepository)
+                    ->call('findCustom')->once()
         ;
     }
 
@@ -284,6 +290,7 @@ class BaseManager extends Units\Test
         $repo                      = $this->mockRepository;
 
         $this->mockRepository->getMockController()->createQueryBuilder = function() use ($qb) { return $qb; };
+        $this->mockRepository->getMockController()->findCustom = function() { };
 
         $this->mockObjectManager = new \mock\Doctrine\Common\Persistence\ObjectManager();
         $this->mockObjectManager->getMockController()->getRepository = function() use ($repo) { return $repo; };


### PR DESCRIPTION
When using BaseManager in our project, we have a lot of proxy method to repositories.

This PR add a magic call to the entity repository if method exists.

Example :
```php
public function findByCategory($category)
{
    return $this->repository->findByCategory($category);
}
```