### PR TITLE
Allow entities located in sub-directories for manager generation

### DIFF
--- a/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Manager/BaseManager.php
@@ -181,7 +181,7 @@ abstract class BaseManager
             }
         }
 
-        $matchTest = sprintf('#^%s:([a-z]+)$#i', $this->bundleName);
+        $matchTest = sprintf('#^%s:([a-z\\\]+)$#i', $this->bundleName);
         if (preg_match($matchTest, $objectName, $match)) {
             if ($objectProperty) {
                 $this->$objectProperty = $match[1];

--- a/src/Skwi/Bundle/ProjectBaseBundle/Tests/FakeBundle/Object/SubDirectory/FakeObject.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Tests/FakeBundle/Object/SubDirectory/FakeObject.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Skwi\Bundle\ProjectBaseBundle\Tests\FakeBundle\Object\SubDirectory;
+
+class FakeObject
+{
+    /** @var bool */
+    private $status = true;
+
+    public function setUpdatedAt()
+    {
+        return;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+}

--- a/src/Skwi/Bundle/ProjectBaseBundle/Tests/Units/Manager/BaseManager.php
+++ b/src/Skwi/Bundle/ProjectBaseBundle/Tests/Units/Manager/BaseManager.php
@@ -48,6 +48,17 @@ class BaseManager extends atoum
         ;
     }
 
+    public function testCreateNewSubDirectoryObject()
+    {
+        $this
+            ->if($testedClass = $this->createTestedClass('SubDirectory\FakeObject'))
+            ->then
+                ->assert('Test createNew without constructor parameters')
+                    ->object($testedClass->createNew())
+                        ->isInstanceOf('\Skwi\Bundle\ProjectBaseBundle\Tests\FakeBundle\Object\SubDirectory\FakeObject')
+        ;
+    }
+
     public function testGetStateProperty()
     {
         $this
@@ -269,7 +280,7 @@ class BaseManager extends atoum
         ;
     }
 
-    private function createTestedClass()
+    private function createTestedClass($object = 'FakeObject')
     {
         $testedClass = new FakeManager();
 
@@ -297,7 +308,7 @@ class BaseManager extends atoum
         $testedClass->setOtherFakeObjectRepository($this->mockOtherRepository);
 
         $testedClass->setObjectManager($this->mockObjectManager);
-        $testedClass->setObject('FakeBundle:FakeObject');
+        $testedClass->setObject(sprintf('FakeBundle:%s', $object));
 
         return $testedClass;
     }


### PR DESCRIPTION
This will allow using entities in sub-directories in manager config.

```
novaway.manager.subentity:
    class: AppBundle\Manager\SubEntityManager
    parent: skwi.projectbase.base_manager
    calls:
      - [setObjectManager, [@doctrine.orm.entity_manager]]
      - [setObject, [AppBundle:Sub\Entity]]
```